### PR TITLE
Added "warn" to logger, enhanced the fix for issue #20

### DIFF
--- a/src/com/bwfcwalshy/jarchecker/Logger.java
+++ b/src/com/bwfcwalshy/jarchecker/Logger.java
@@ -61,6 +61,17 @@ public class Logger {
 		String x = getTime() + " [ERROR] " + msg;
 		printNoInfo(x);
 	}
+	
+	/**
+	 * Will print the message with the prefix "{@link #getTime()} [WARN] "
+	 * 
+	 * @param msg
+	 *            The message to print
+	 */
+	public static void warn(String msg) {
+		String x = getTime() + " [WARN] " + msg;
+		printNoInfo(x);
+	}
 
 	/**
 	 * Will print the exception with the prefix: "{@link #getTime()} [ERROR]"


### PR DESCRIPTION
Added a "warn" method to the logger, as it came in handy.

I think I fixed #20 

Enhanced the shutdown check to try to find and check the type of the
variable shutdown is invoked onto. Kept ArsenArsen's regex, just added
more handling if it is not
"Bukkit#shutdown()" or "Bukkit#getServer()#shutdown()"
but
"Server server = Bukkit#getServer()"
"server#shutdown()"

This should now be identified correctly. Emphasis on should. I hope this
doesn't introduce any new bugs, having something to test it with would
be nice ;)

Formatting now has no visual change for me, but github still thinks it is different. Do you see the difference? Can't be the file encoding, can it?

And I know I can push, but creating a pull request seems safer ;)